### PR TITLE
Add omero_ms_image_region_group variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Role Variables
 --------------
 
 - `omero_ms_image_region_user`: The microservice user, the default is `omero-server`
-- `omero_ms_image_region_group`: The microservice group, the default is omero_ms_image_region_user
+- `omero_ms_image_region_group`: The microservice group, the default is `omero-server` (the same as the value of `omero_ms_image_region_user`)
 - `omero_ms_image_region_folder`: The microservice installation folder
 - `omero_ms_image_region_port`: The microservice port 
 - `omero_ms_image_region_db_url`: The OMERO database URL

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Role Variables
 --------------
 
 - `omero_ms_image_region_user`: The microservice user, the default is `omero-server`
+- `omero_ms_image_region_group`: The microservice group, the default is omero_ms_image_region_user
 - `omero_ms_image_region_folder`: The microservice installation folder
 - `omero_ms_image_region_port`: The microservice port 
 - `omero_ms_image_region_db_url`: The OMERO database URL

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@
 # Microservice user, the defaults is OMERO.server
 omero_ms_image_region_user: 'omero-server'
 
+# Microservice group, default is same as user:
+omero_ms_image_region_group: "{{ omero_ms_image_region_user }}"
+
 # Microservice installation folder
 omero_ms_image_region_folder: '/opt/omero/microservice'
 

--- a/tasks/pre_tasks.yml
+++ b/tasks/pre_tasks.yml
@@ -29,7 +29,7 @@
   ansible.builtin.file:
     path: "{{ omero_ms_image_region_folder }}"
     owner: "{{ omero_ms_image_region_user }}"
-    group: "{{ omero_ms_image_region_group or omero_ms_image_region_user }}"
+    group: "{{ omero_ms_image_region_group }}"
     state: directory
     recurse: true
     mode: 0755

--- a/tasks/pre_tasks.yml
+++ b/tasks/pre_tasks.yml
@@ -29,7 +29,7 @@
   ansible.builtin.file:
     path: "{{ omero_ms_image_region_folder }}"
     owner: "{{ omero_ms_image_region_user }}"
-    group: "{{ omero_ms_image_region_user }}"
+    group: "{{ omero_ms_image_region_group or omero_ms_image_region_user }}"
     state: directory
     recurse: true
     mode: 0755


### PR DESCRIPTION
The step in pretask assumes that there's also a group `omero_ms_image_region_user`, but that might not be the case. This PR just adds an optional `omero_ms_image_region_group` for these cases.
